### PR TITLE
Refer to gap.ini instead of .gaprc

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If polymake is not found automatically (a warning will be printed at
 level 1 in this case), try this:
 
 6. Tell GAP where to look for polymake by adding the following lines to
-   your `.gaprc` file:
+   your `gap.ini` file:
 
         POLYMAKE_COMMAND:=Filename(Directory("/home/mypolymakebindir/"),"polymake");
         MakeImmutable(POLYMAKE_COMMAND);

--- a/doc/environment.xml
+++ b/doc/environment.xml
@@ -84,7 +84,7 @@ POLYMAKE_DATA_DIR:=Directory("/home/mypolymakedatadir");
 POLYMAKE_COMMAND:=Filename(Directory("/home/mypolymakebindir/"),"polymake");
 </Listing>
 
-       to your <F>.gaprc</F> file (see <Ref Label="The .gaprc file"
+       to your <F>gap.ini</F> file (see <Ref Label="The gap.ini and gaprc files"
        BookName="ref"></Ref>). Note that these have to be
        <Emph>before</Emph> the <C>LoadPackage("polymaking");</C> line.
        Or you can change the values of the above variables by editing

--- a/doc/internals.xml
+++ b/doc/internals.xml
@@ -31,7 +31,7 @@ output</Heading>
   <K>POLYMAKE&uscore;COMMAND</K> or <K>POLYMAKE&uscore;DATA&uscore;DIR</K> are set at
   startup, they are not overwritten. So if you don't want (or don't
   have the rights) to modify <F>environment.gi</F>, you can set the
-  variables in your <F>.gaprc</F> file.
+  variables in your <F>gap.ini</F> file.
     
    <ManSection>
     <Var Name="POLYMAKE_COMMAND"/>


### PR DESCRIPTION
This also fixes the broken reference in `doc/environment.xml`.