### PR TITLE
Fix URL command in polymaking.bib

### DIFF
--- a/doc/polymaking.bib
+++ b/doc/polymaking.bib
@@ -18,5 +18,5 @@
 @Misc{polymake,
   author = 	 "Ewgenij Gawrilow and Michael Joswig",
   title = 	 {polymake},
-  howpublished = {\URL{http://polymake.org/}}
+  howpublished = {\url{http://polymake.org/}}
 }


### PR DESCRIPTION
This causes a LaTeX error and prevents the bibliography from correctly being displayed.